### PR TITLE
#52 Add ability to specify file path for Manual provider

### DIFF
--- a/ACMESharp/ACMESharp.POSH/Vault/ProviderConfig.cs
+++ b/ACMESharp/ACMESharp.POSH/Vault/ProviderConfig.cs
@@ -22,5 +22,8 @@ namespace ACMESharp.POSH.Vault
 
         public string WebServerProvider
         { get; set; }
+
+        public string FilePath
+        { get; set; }
     }
 }


### PR DESCRIPTION
This is a little hacky, but this part of the code already seems a little hacky to start with ;-)

Works well though, and I can now specify a path and do a complete end-to-end request for certificate without touching the keyboard!